### PR TITLE
Improved exception info

### DIFF
--- a/coffin/template/defaulttags.py
+++ b/coffin/template/defaulttags.py
@@ -202,14 +202,14 @@ class URLExtension(Extension):
         try:
             url = reverse(viewname, urlconf=urlconf, args=args, kwargs=kwargs,
                 current_app=current_app)
-        except NoReverseMatch:
+        except NoReverseMatch as ex:
             projectname = settings.SETTINGS_MODULE.split('.')[0]
             try:
                 url = reverse(projectname + '.' + viewname, urlconf=urlconf, 
                               args=args, kwargs=kwargs)
             except NoReverseMatch:
                 if fail:
-                    raise
+                    raise ex
                 else:
                     return ''
 


### PR DESCRIPTION
If the NoReverseMatch exception occurs in the URLExtension._reverse method, there is an attempt of new reverse with the project name. But only the second exception has been raised if reverse fails again.
So, if I made a mistake in my urls.py:
```python
# some/urls.py
url(r'^some-incorrect-url-pattern$', view, name)
```
and included its with some namespace:
```python
url(r'^', include('some.urls', namespace='some-namespace'))
```
I have the wrong exception message <b>u'projectname.namespace' is not a registered namespace</b>.
It would be nice, if the initial exception will be raised.