### PR TITLE
Template.render understands jinja2 contexts now

### DIFF
--- a/coffin/template/__init__.py
+++ b/coffin/template/__init__.py
@@ -48,6 +48,9 @@ class Template(_Jinja2Template):
         """
         dict_ = {}
 
+        if isinstance(context, dict):
+            dict_ = context
+
         if isinstance(context, DjangoContext):
             dict_ = dict_from_django_context(context)
 


### PR DESCRIPTION
I've opened this pull request for getiing this code work:

```python
from coffin import template
from jinja2 import contextfilter

register = template.Library()

@register.filter
@contextfilter
def render(context, value):
    return value.render(context)
```

I have forms with `render` method, who need current context:

```
{{ form|render }}
```