### PR TITLE
Django 1.8 compat

### DIFF
--- a/coffin/common.py
+++ b/coffin/common.py
@@ -80,8 +80,14 @@ class CoffinEnvironment(Environment):
         register all libraries globally.
         """
         from django.conf import settings
-        from django.template import (
-            get_library, import_library, InvalidTemplateLibrary)
+        try:
+            from django.template import (
+                get_library, import_library, InvalidTemplateLibrary
+            )
+        except ImportError:
+            from django.template.base import (
+                get_library, import_library, InvalidTemplateLibrary
+            )
 
         libs = []
         for app in settings.INSTALLED_APPS:
@@ -113,8 +119,12 @@ class CoffinEnvironment(Environment):
 
     def _get_all_extensions(self):
         from django.conf import settings
-        from django.template import builtins as django_builtins
-        from coffin.template import builtins as coffin_builtins
+        try:
+            from django.template import builtins as django_builtins
+            from coffin.template import builtins as coffin_builtins
+        except ImportError:
+            from django.template.base import builtins as django_builtins
+            from coffin.template.base import builtins as coffin_builtins
         from django.core.urlresolvers import get_callable
 
         # Note that for extensions, the order in which we load the libraries

--- a/coffin/template/__init__.py
+++ b/coffin/template/__init__.py
@@ -1,8 +1,13 @@
-from django.template import (
-    Context as DjangoContext,
-    add_to_builtins as django_add_to_builtins,
-    import_library,
-)
+from django.template import Context as DjangoContext
+
+try:
+    from django.template import add_to_builtins as django_add_to_builtins
+except ImportError:
+    from django.template.base import add_to_builtins as django_add_to_builtins
+    from django.template.base import import_library
+else:
+    from django.template import import_library
+
 from jinja2 import Template as _Jinja2Template
 from jinja2.runtime import Context as _Jinja2Context
 

--- a/coffin/template/__init__.py
+++ b/coffin/template/__init__.py
@@ -14,7 +14,11 @@ from jinja2.runtime import Context as _Jinja2Context
 # Merge with ``django.template``.
 from django.template import __all__
 from django.template import *
-from django.template import Origin
+try:
+    from django.template import Origin
+except ImportError:
+    from django.template.base import Origin
+
 from django.test import signals
 
 # Override default library class with ours

--- a/coffin/template/library.py
+++ b/coffin/template/library.py
@@ -1,4 +1,8 @@
-﻿from django.template import Library as DjangoLibrary, InvalidTemplateLibrary
+﻿from django.template import Library as DjangoLibrary
+try:
+    from django.template import InvalidTemplateLibrary
+except ImportError:
+    from django.template.base import InvalidTemplateLibrary
 from jinja2.ext import Extension as Jinja2Extension
 import types
 from coffin.interop import (

--- a/coffin/template/loaders.py
+++ b/coffin/template/loaders.py
@@ -24,7 +24,11 @@ def _make_jinja_app_loader():
     """Makes an 'app loader' for Jinja which acts like
     :mod:`django.template.loaders.app_directories`.
     """
-    from django.template.loaders.app_directories import app_template_dirs
+    try:
+        from django.template.loaders.app_directories import app_template_dirs
+    except ImportError:
+        from django.template.utils import get_app_template_dirs
+        app_template_dirs = get_app_template_dirs('templates')
     return loaders.FileSystemLoader(app_template_dirs)
 
 


### PR DESCRIPTION
This is still not sufficient as django_jinja itself is [currently not compatible with django 1.8](https://github.com/niwibe/django-jinja/issues/92). 

